### PR TITLE
Replace PPT with PDF

### DIFF
--- a/replace-ppt-with-pdf.applescript
+++ b/replace-ppt-with-pdf.applescript
@@ -1,0 +1,31 @@
+on run {input, parameters}
+	set theOutput to {}
+	repeat with i in input
+		set t to i as string
+		if t ends with ".ppt" or ".pptx" then
+			set pdfPath to my makeNewPath(i)
+			tell application "Microsoft PowerPoint" -- work on version 15.15 or newer
+				open i
+				set theDial to start up dialog
+				set start up dialog to false
+				save active presentation in pdfPath as save as PDF -- save in same folder
+				set start up dialog to theDial
+				quit
+				set end of theOutput to pdfPath as alias
+				tell application "Finder"
+					delete i
+				end tell
+			end tell
+		end if
+	end repeat
+	return theOutput
+end run
+
+on makeNewPath(f)
+	set t to f as string
+	if t ends with ".pptx" then
+		return (text 1 thru -5 of t) & "pdf"
+	else
+		return (text 1 thru -4 of t) & "pdf"
+	end if
+end makeNewPath

--- a/replace-ppt-with-pdf.applescript
+++ b/replace-ppt-with-pdf.applescript
@@ -1,21 +1,23 @@
 on run {input, parameters}
 	set theOutput to {}
-	repeat with i in input
-		set t to i as string
-		if t ends with ".ppt" or ".pptx" then
-			set pdfPath to my makeNewPath(i)
-			tell application "Microsoft PowerPoint" -- work on version 15.15 or newer
-				launch
+	tell application "Microsoft PowerPoint" -- work on version 15.15 or newer
+		launch
+		repeat with i in input
+			set t to i as string
+			if t ends with ".ppt" or t ends with ".pptx" then
+				set pdfPath to my makeNewPath(i)
 				open i
 				save active presentation in pdfPath as save as PDF -- save in same folder
-				quit
 				set end of theOutput to pdfPath as alias
 				tell application "Finder"
 					delete i
 				end tell
-			end tell
-		end if
-	end repeat
+			end if
+		end repeat
+	end tell
+	tell application "Microsoft PowerPoint" -- work on version 15.15 or newer
+		quit
+	end tell
 	return theOutput
 end run
 

--- a/replace-ppt-with-pdf.applescript
+++ b/replace-ppt-with-pdf.applescript
@@ -5,11 +5,9 @@ on run {input, parameters}
 		if t ends with ".ppt" or ".pptx" then
 			set pdfPath to my makeNewPath(i)
 			tell application "Microsoft PowerPoint" -- work on version 15.15 or newer
+				launch
 				open i
-				set theDial to start up dialog
-				set start up dialog to false
 				save active presentation in pdfPath as save as PDF -- save in same folder
-				set start up dialog to theDial
 				quit
 				set end of theOutput to pdfPath as alias
 				tell application "Finder"


### PR DESCRIPTION
Delete the original ppt file After creating a pdf from it.
I have tested successfully and optimized the code as follows:
1. Only perform the process when necessary (skip when the file extension is not ppt or pptx)
2. Quit the power point app as early as possible (In specific, set the output file name and delete the original file after closing the power point app.)
3. Delete redundant lines (removing the code related to `dialog` will not affect our result)

Please review. Thanks!!